### PR TITLE
Relative snippet path

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Add the doclet to your Maven Javadoc plugin configuration
      <docletArtifact>
        <groupId>org.apidesign.javadoc</groupId>
        <artifactId>codesnippet-doclet</artifactId>
-       <version>0.22</version> <!-- or any newer version -->
+       <version>0.23</version> <!-- or any newer version -->
      </docletArtifact>
      <!-- if you want to reference snippets from your test directory, also include -->
-     <additionalparam>-snippetpath "${basedir}/src/test/java"</additionalparam>
+     <additionalparam>-snippetpath src/test/java</additionalparam>
     </configuration>
 </plugin>
 ```

--- a/doclet/src/main/java/org/apidesign/javadoc/codesnippet/Doclet.java
+++ b/doclet/src/main/java/org/apidesign/javadoc/codesnippet/Doclet.java
@@ -39,6 +39,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -128,7 +129,7 @@ public final class Doclet {
             if (visible != null) {
                 for (int i = 1; i < optionAndParams.length; i++) {
                     for (String elem : optionAndParams[i].split(File.pathSeparator)) {
-                        snippets.addPath(new File(elem).toPath(), visible);
+                        snippets.addPath(findAbsolutePath(elem), visible);
                     }
                 }
             }
@@ -159,6 +160,21 @@ public final class Doclet {
             }
         }
         return HtmlDoclet.validOptions(options, reporter);
+    }
+
+    private static Path findAbsolutePath(String elem) {
+        File file = new File(elem);
+        if (file.isAbsolute()) {
+            return file.toPath();
+        } else {
+            File root = new File(".").getAbsoluteFile();
+            while (!file.exists() && root != null) {
+                file = new File(root, elem);
+                root = root.getParentFile();
+            }
+            return file.getAbsoluteFile().toPath();
+        }
+
     }
 
     public static LanguageVersion languageVersion() {

--- a/doclet/src/main/java/org/apidesign/javadoc/codesnippet/Snippets.java
+++ b/doclet/src/main/java/org/apidesign/javadoc/codesnippet/Snippets.java
@@ -25,8 +25,10 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.MalformedInputException;
+import java.nio.charset.UnmappableCharacterException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
@@ -279,6 +281,8 @@ final class Snippets {
                     }
                 } catch (MalformedInputException ex) {
                     printWarning(null, "Skipping binary file " + file.toString());
+                } catch (CharacterCodingException ex) {
+                    printWarning(null, "Skipping binary file " + file.toString());
                 } catch (IOException ex) {
                     printError(null, "Cannot read " + file.toString() + " " + ex.getMessage());
                 }
@@ -354,7 +358,7 @@ final class Snippets {
         });
     }
 
-    private void printWarning(Doc where, String msg) {
+    final void printWarning(Doc where, String msg) {
         if (reporter != null) {
             if (where == null) {
                 reporter.printWarning(msg);
@@ -366,7 +370,7 @@ final class Snippets {
         }
     }
 
-    private void printError(Doc where, String msg) {
+    final void printError(Doc where, String msg) {
         if (reporter != null) {
             if (where == null) {
                 reporter.printError(msg);

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -40,7 +40,7 @@
                     </docletArtifact>
                     <additionalJOption>${debug}</additionalJOption>
                     <additionalparam>
--snippetpath "${basedir}/src/test/java"
+-snippetpath src/test/java
 -snippetclasses ".*Snippet.*" 
 -maxLineLength 80 
 -hiddingannotation java.lang.Deprecated 


### PR DESCRIPTION
Workaround problem with \\ on windows by using only relative part of the path.