### PR TITLE
Dollar sign in snippets must not be considered as a capture instruction

### DIFF
--- a/doclet/src/main/java/org/apidesign/javadoc/codesnippet/Snippets.java
+++ b/doclet/src/main/java/org/apidesign/javadoc/codesnippet/Snippets.java
@@ -485,7 +485,8 @@ final class Snippets {
                         append = "{@link " + fqn + "}";
                     }
             }
-            append = append.replace("\\", "\\\\");
+            append = append.replace("\\", "\\\\")
+                    .replace("$", "\\$");
             m.appendReplacement(sb, append);
         }
         m.appendTail(sb);

--- a/testing/src/main/java/org/apidesign/javadoc/testing/SpecialCharacters.java
+++ b/testing/src/main/java/org/apidesign/javadoc/testing/SpecialCharacters.java
@@ -1,0 +1,32 @@
+/**
+ * Codesnippet Javadoc Doclet
+ * Copyright (C) 2015-2018 Jaroslav Tulach - jaroslav.tulach@apidesign.org
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.0 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. Look for COPYING file in the top folder.
+ * If not, see http://opensource.org/licenses/GPL-3.0.
+ */
+package org.apidesign.javadoc.testing;
+
+/** Class with special characters to be properly escaped
+ * {@codesnippet dollarSnippet1}
+ * {@codesnippet dollarSnippet2}
+ */
+public class SpecialCharacters {
+    // BEGIN: dollarSnippet1
+    public static final String MY_MONEY = "$100.00";
+    // END: dollarSnippet1
+
+    // BEGIN: dollarSnippet2
+    public static final String MONEY_SIGNS = "$ € £";
+    // END: dollarSnippet2
+}

--- a/testing/src/test/java/org/apidesign/javadoc/testing/VerifyJavadocTest.java
+++ b/testing/src/test/java/org/apidesign/javadoc/testing/VerifyJavadocTest.java
@@ -223,6 +223,20 @@ public class VerifyJavadocTest {
         assertSnippet(text, "sample1", "<b>int</b> x = 42;");
     }
 
+    @Test
+    public void testSnippetWithSpecialCharacters() throws Exception {
+        ClassLoader l = VerifyJavadocTest.class.getClassLoader();
+        URL url = l.getResource("apidocs/org/apidesign/javadoc/testing/SpecialCharacters.html");
+        assertNotNull(url, "Generated page for package found");
+        File file = new File(url.toURI());
+        assertTrue(file.exists(), "File found " + file);
+
+        byte[] data = Files.readAllBytes(file.toPath());
+        String text = new String(data);
+        assertSnippet(text, "dollarSnippet1", "MY_MONEY = <em>\"$100.00\"</em>");
+        assertSnippet(text, "dollarSnippet2", "MONEY_SIGNS = <em>\"$ € £\"</em>");
+    }
+
     private void assertSnippet(String text, final String snippetKey, final String snippetText) {
         int from = 0;
         for (;;) {


### PR DESCRIPTION
I had this bug when snippet contained strings with $.

If $ is followed by a number, the Javadoc is not properly formatted.
If $ is followed by a space, the Javadoc command throws an exception : 

`javadoc: error - In doclet class org.apidesign.javadoc.codesnippet.Doclet,  method start has thrown an exception java.lang.reflect.InvocationTargetException
java.lang.IllegalArgumentException: Illegal group reference
        at java.util.regex.Matcher.appendReplacement(Matcher.java:857)
        at org.apidesign.javadoc.codesnippet.Snippets.boldJavaKeywords(Snippets.java:489)
        at org.apidesign.javadoc.codesnippet.Snippets$Item.toString(Snippets.java:651)
        at org.apidesign.javadoc.codesnippet.Snippets$1.visitFile(Snippets.java:262)
        at org.apidesign.javadoc.codesnippet.Snippets$1.visitFile(Snippets.java:216)
        at java.nio.file.Files.walkFileTree(Files.java:2670)
        at java.nio.file.Files.walkFileTree(Files.java:2742)
        at org.apidesign.javadoc.codesnippet.Snippets.scanDir(Snippets.java:216)
        at org.apidesign.javadoc.codesnippet.Snippets.findSnippet(Snippets.java:190)
        at org.apidesign.javadoc.codesnippet.Snippets.fixCodesnippets(Snippets.java:84)
        at org.apidesign.javadoc.codesnippet.Doclet.start(Doclet.java:52)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at com.sun.tools.javadoc.DocletInvoker.invoke(DocletInvoker.java:310)
        at com.sun.tools.javadoc.DocletInvoker.start(DocletInvoker.java:189)
        at com.sun.tools.javadoc.Start.parseAndExecute(Start.java:366)
        at com.sun.tools.javadoc.Start.begin(Start.java:219)
        at com.sun.tools.javadoc.Start.begin(Start.java:205)
        at com.sun.tools.javadoc.Main.execute(Main.java:64)
        at com.sun.tools.javadoc.Main.main(Main.java:54)
1 error
`