### PR TITLE
Catch RuntimeException when trying to find the annotation name

### DIFF
--- a/doclet/src/main/java/org/apidesign/javadoc/codesnippet/Doclet.java
+++ b/doclet/src/main/java/org/apidesign/javadoc/codesnippet/Doclet.java
@@ -39,6 +39,8 @@ import java.lang.reflect.Proxy;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.Callable;
 
 /**
@@ -254,8 +256,7 @@ public final class Doclet {
                     List<Object> copy = new ArrayList<>();
                     for (Object element : arr) {
                         boolean skip = false;
-                        for (AnnotationDesc desc : findAnnotations(element)) {
-                            String name = desc.annotationType().qualifiedName();
+                        for (String name : findAnnotationsNames(element)) {
                             if (snippets.isHiddingAnnotation(name)) {
                                 skip = doSkip;
                                 break;
@@ -284,6 +285,19 @@ public final class Doclet {
                 return ((PackageDoc) element).annotations();
             }
             return new AnnotationDesc[0];
+        }
+
+        private Iterable<String> findAnnotationsNames(Object element) {
+            Set<String> names = new TreeSet<>();
+            for (AnnotationDesc desc : findAnnotations(element)) {
+                try {
+                    String name = desc.annotationType().qualifiedName();
+                    names.add(name);
+                } catch (RuntimeException ex) {
+                    ex.printStackTrace();
+                }
+            }
+            return names;
         }
     }
 }


### PR DESCRIPTION
When using the `codesnippet4javadoc` doclet on the [Graal repository](https://github.com/oracle/graal) following problem was noticed:
```bash
WARNING: stderr: com.sun.tools.javac.code.Symbol$CompletionFailure: class file for jdk.vm.ci.common.NativeImageReinitialize not found
WARNING: stderr: javadoc: error - class file for jdk.vm.ci.common.NativeImageReinitialize not found
# the stack was:
"main"
    at com.sun.tools.javac.code.ClassFinder.fillIn(ClassFinder.java:388)
    at com.sun.tools.javac.code.ClassFinder.complete(ClassFinder.java:291)
    at com.sun.tools.javac.code.ClassFinder$$Lambda$60.2084663827.complete
    at com.sun.tools.javac.code.Symbol.complete(Symbol.java:642)
    at com.sun.tools.javac.code.Symbol$ClassSymbol.complete(Symbol.java:1326)
    at com.sun.tools.javac.code.Type$ClassType.complete(Type.java:1140)
    at com.sun.tools.javac.code.Type$ClassType.getTypeArguments(Type.java:1066)
    at com.sun.tools.javac.code.Type$ClassType.isErroneous(Type.java:1096)
    at com.sun.tools.javac.code.Type$ClassType.isErroneous(Type.java:1097)
    at com.sun.tools.javadoc.main.AnnotationDescImpl.annotationType(AnnotationDescImpl.java:69)
    at org.apidesign.javadoc.codesnippet.Doclet$DocProxy.invoke(Doclet.java:258)
    at com.sun.proxy.$Proxy1.fields
    at com.sun.tools.oldlets.internal.toolkit.util.VisibleMemberMap$ClassMembers.getClassMembers(VisibleMemberMap.java:457)
    at com.sun.tools.oldlets.internal.toolkit.util.VisibleMemberMap$ClassMembers.addMembers(VisibleMemberMap.java:387)
```
and the value of the element causing the problem was from [GraalTruffleRuntime](https://github.com/oracle/graal/blob/master/compiler/src/org.graalvm.compiler.truffle.runtime/src/org/graalvm/compiler/truffle/runtime/GraalTruffleRuntime.java):
```java
@NativeImageReinitialize private volatile Map<String, Object> initialOptions;
```
This fix just catches any `RuntimeException` and proceeds.
