### PR TITLE
Add flag to suppress warnings if link to a type is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,23 @@ overview (however their individual HTML pages still remain in Javadoc for those 
 can use the `-hiddingannotation` parameter with other annotations as well and even repeat the parameter multiple times
 to hide multiple annotations at once.
 
+## Linking types
+
+The doclet searches existing `import` statements in the code snippet and tries to link the Java files in the package. 
+When a matching type is found, the identifier is wrapped with `@link`. Note that the linking is best-effort only and when 
+the type is not found, a warning message is logged `Tag @link: reference not found: <classname>`. 
+
+You can suppress the warning by passing the parameter `-suppressMissingLinkWarnings` as shown below. This parameter will 
+convert the warning to an informational message, so, you can continue to see the types that are missing links and not 
+fail the build on warnings if `failOnWarnings` flag is set in your javadoc configuration.
+
+```bash
+$ javadoc \
+  -doclet org.apidesign.javadoc.codesnippet.Doclet \
+  -docletpath path/to/downloaded/codesnippet-doclet.jar \
+  -suppressMissingLinkWarnings
+```
+
 ## License
 
 Feel free to use the Codesnippet Doclet binary to generate any public or private Javadoc. If you include the Codesnippet Doclet in your product or make modifications to it, please obey its *GPL 3.0* license.

--- a/doclet/src/main/java/com/sun/tools/oldlets/formats/html/ConfigurationImpl.java
+++ b/doclet/src/main/java/com/sun/tools/oldlets/formats/html/ConfigurationImpl.java
@@ -342,7 +342,8 @@ public class ConfigurationImpl extends Configuration {
             option.equals("-nooverview") ||
             option.equals("-xdoclint") ||
             option.startsWith("-xdoclint:") ||
-            option.equals("--allow-script-in-comments")) {
+            option.equals("--allow-script-in-comments") ||
+            option.equals("-suppressmissinglinkwarnings")) {
             return 1;
         } else if (option.equals("-help")) {
             // Uugh: first, this should not be hidden inside optionLength,

--- a/doclet/src/main/java/com/sun/tools/oldlets/formats/html/HtmlDocletWriter.java
+++ b/doclet/src/main/java/com/sun/tools/oldlets/formats/html/HtmlDocletWriter.java
@@ -1400,9 +1400,15 @@ public class HtmlDocletWriter extends HtmlDocWriter {
                     //Class cross link found (possibly to a member in the class)
                     return classCrossLink;
                 } else {
-                    //No cross link found so print warning
-                    configuration.getDocletSpecificMsg().warning(see.position(), "doclet.see.class_or_package_not_found",
-                            tagName, seetext);
+                    if (configuration.suppressMissingLinkWarnings) {
+                        // suppress warning flag set; just print a notice
+                        configuration.getDocletSpecificMsg()
+                          .notice(see.position(), "doclet.see.class_or_package_not_found", tagName, seetext);
+                    } else {
+                        //No cross link found so print warning
+                        configuration.getDocletSpecificMsg()
+                            .warning(see.position(), "doclet.see.class_or_package_not_found", tagName, seetext);
+                    }
                     return (label.isEmpty() ? text: label);
                 }
             }

--- a/doclet/src/main/java/com/sun/tools/oldlets/internal/toolkit/Configuration.java
+++ b/doclet/src/main/java/com/sun/tools/oldlets/internal/toolkit/Configuration.java
@@ -263,6 +263,12 @@ public abstract class Configuration {
     public final Extern extern = new Extern(this);
 
     /**
+     * The flag to suppress warning messages from being logged when links to resources/classes are not found.
+     * If this value is set to true, a notice (informational message) will be logged instead.
+     */
+    public boolean suppressMissingLinkWarnings = false;
+
+    /**
      * Return the build date for the doclet.
      */
     public abstract String getDocletSpecificBuildDate();
@@ -530,6 +536,8 @@ public abstract class Configuration {
                 String url = os[1];
                 String pkglisturl = os[2];
                 extern.link(url, pkglisturl, root, true);
+            } else if(opt.equals("-suppressmissinglinkwarnings")) {
+                suppressMissingLinkWarnings = true;
             }
         }
         if (sourcepath.length() == 0) {


### PR DESCRIPTION
The intent of this change is to add a flag to suppress warnings from being logged when linking fails to find the class. If this flag is set, when linking fails, a notice is logged instead of a warning. This will allow consumers of this snippet to enable `failOnWarning` for javadoc warnings and not fail the build when link is missing.

To use this feature, just add `-suppressMissingLinkWarnings` flag to `additionalOptions` in Maven's javadoc plugin configuration section.

Fixes #17 