### PR TITLE
Re-introduce the suppressMissingLinkWarnings flag

### DIFF
--- a/doclet/src/main/java/org/apidesign/javadoc/codesnippet/Doclet.java
+++ b/doclet/src/main/java/org/apidesign/javadoc/codesnippet/Doclet.java
@@ -120,7 +120,8 @@ public final class Doclet implements jdk.javadoc.doclet.Doclet {
         HIDINGANNOTATION(2, "-hiddingannotation"),
         VERIFYSINCE(1, "-verifysince"),
         VERIFYSINCEPRESENT(1, "-verifysincepresent"),
-        ENCODING(2, "-encoding");
+        ENCODING(2, "-encoding"),
+        SUPPRESSMISSINGLINKWARNINGS(1, "-suppressmissinglinkwarnings");
 
         final int length;
         final String name;


### PR DESCRIPTION
Re-introducing the `suppressMissingLinkWarnings` that were introduced in #18 . 

I am not sure if this change is sufficient as I couldn't fully generate the Javadoc because of the issue reported  here - https://github.com/jtulach/codesnippet4javadoc/issues/14 