### PR TITLE
Read package list from element-list file for JDK 10 and above

### DIFF
--- a/doclet/src/main/java/com/sun/tools/oldlets/internal/toolkit/util/DocPaths.java
+++ b/doclet/src/main/java/com/sun/tools/oldlets/internal/toolkit/util/DocPaths.java
@@ -110,6 +110,9 @@ public class DocPaths {
     /** The name of the file for the package list. */
     public static final DocPath PACKAGE_LIST = DocPath.create("package-list");
 
+    /** The name of the file for package list since JDK 10. */
+    public static final DocPath ELEMENT_LIST = DocPath.create("element-list");
+
     /** The name of the file for the package summary. */
     public static final DocPath PACKAGE_SUMMARY = DocPath.create("package-summary.html");
 

--- a/doclet/src/main/java/com/sun/tools/oldlets/internal/toolkit/util/Extern.java
+++ b/doclet/src/main/java/com/sun/tools/oldlets/internal/toolkit/util/Extern.java
@@ -273,14 +273,12 @@ public class Extern {
             && !isUrl(path);
         if (packageListFile.exists() && packageListFile.canRead()) {
             try {
-                System.out.println("USING PACKAGE-LIST");
                 readPackageList(packageListFile.openInputStream(), path, isPathRelative);
             } catch (IOException ex) {
                 throw new Fault(configuration.getText("doclet.File_error", packageListFile.getPath()), ex);
             }
         } else if (elementListFile.exists() && elementListFile.canRead()) {
             try {
-                System.out.println("USING ELEMENT-LIST");
                 readPackageList(elementListFile.openInputStream(), path, isPathRelative);
             } catch (IOException ex) {
                 throw new Fault(configuration.getText("doclet.File_error", elementListFile.getPath()), ex);

--- a/doclet/src/main/java/com/sun/tools/oldlets/internal/toolkit/util/Extern.java
+++ b/doclet/src/main/java/com/sun/tools/oldlets/internal/toolkit/util/Extern.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import javax.tools.DocumentationTool;
 
 import com.sun.tools.oldlets.internal.toolkit.*;
+import javax.tools.DocumentationTool.Location;
 
 /**
  * Process and manage "-link" and "-linkoffline" to external packages. The
@@ -248,33 +249,52 @@ public class Extern {
      * Read the "package-list" file which is available locally.
      *
      * @param path URL or directory path to the packages.
-     * @param pkgListPath Path to the local "package-list" file.
+     * @param pkgListPath Path to the local "package-list" or "element-list" (for JDK 10 or greater) file.
      */
     private void readPackageListFromFile(String path, DocFile pkgListPath)
             throws Fault {
-        DocFile file = pkgListPath.resolve(DocPaths.PACKAGE_LIST);
-        if (! (file.isAbsolute() || linkoffline)){
-            file = file.resolveAgainst(DocumentationTool.Location.DOCUMENTATION_OUTPUT);
+        DocFile packageListFile = pkgListPath.resolve(DocPaths.PACKAGE_LIST);
+        DocFile elementListFile = pkgListPath.resolve(DocPaths.ELEMENT_LIST);
+
+        if (!(packageListFile.isAbsolute() || linkoffline)) {
+            packageListFile = packageListFile.resolveAgainst(Location.DOCUMENTATION_OUTPUT);
         }
-        try {
-            if (file.exists() && file.canRead()) {
-                boolean pathIsRelative =
-                        !DocFile.createFileForInput(configuration, path).isAbsolute()
-                        && !isUrl(path);
-                readPackageList(file.openInputStream(), path, pathIsRelative);
-            } else {
-                throw new Fault(configuration.getText("doclet.File_error", file.getPath()), null);
+
+        // JDK 10 onwards, package-list file was renamed to element-list and this method should
+        // attempt to read the package list from either of these files. The first preference is to look
+        // for package-list and if this is not found try element-list and if that's also not found, throw an
+        // exception (which will log a warning).
+        // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8191363
+        if (!(elementListFile.isAbsolute() || linkoffline)) {
+            elementListFile = elementListFile.resolveAgainst(Location.DOCUMENTATION_OUTPUT);
+        }
+
+        boolean isPathRelative = !DocFile.createFileForInput(configuration, path).isAbsolute()
+            && !isUrl(path);
+        if (packageListFile.exists() && packageListFile.canRead()) {
+            try {
+                System.out.println("USING PACKAGE-LIST");
+                readPackageList(packageListFile.openInputStream(), path, isPathRelative);
+            } catch (IOException ex) {
+                throw new Fault(configuration.getText("doclet.File_error", packageListFile.getPath()), ex);
             }
-        } catch (IOException exc) {
-           throw new Fault(configuration.getText("doclet.File_error", file.getPath()), exc);
+        } else if (elementListFile.exists() && elementListFile.canRead()) {
+            try {
+                System.out.println("USING ELEMENT-LIST");
+                readPackageList(elementListFile.openInputStream(), path, isPathRelative);
+            } catch (IOException ex) {
+                throw new Fault(configuration.getText("doclet.File_error", elementListFile.getPath()), ex);
+            }
+        } else {
+            throw new Fault(configuration.getText("doclet.File_error", packageListFile.getPath()), null);
         }
     }
 
     /**
-     * Read the file "package-list" and for each package name found, create
+     * Read the file "package-list" or "element-list" and for each package name found, create
      * Extern object and associate it with the package name in the map.
      *
-     * @param input    InputStream from the "package-list" file.
+     * @param input    InputStream from the "package-list" or "element-list" file.
      * @param path     URL or the directory path to the packages.
      * @param relative Is path relative?
      */

--- a/pom.xml
+++ b/pom.xml
@@ -142,5 +142,24 @@
                 <module>classfinderpatch</module>
             </modules>
         </profile>
+        <profile>
+            <id>java-10</id>
+            <activation>
+                <jdk>[10,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.3</version>
+                        <configuration>
+                            <source>10</source>
+                            <target>10</target>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -75,6 +75,15 @@
 -header Header -bottom Bottom -group Extra org.apidesign.javadoc.testing:org.apidesign.javadoc ${testing.doclint}
                     </additionalOptions>
                     <failOnWarnings>true</failOnWarnings>
+                    <links>
+                        <!-- JDK 10 and above uses element-list link -->
+                        <!-- https://docs.oracle.com/javase/10/docs/api/element-list is a downloadable file -->
+                        <link>https://docs.oracle.com/javase/10/docs/api/</link>
+
+                        <!-- Reactor uses the older filename package-list -->
+                        <!-- https://projectreactor.io/docs/core/release/api/package-list is a downloadable file -->
+                        <link>https://projectreactor.io/docs/core/release/api/</link>
+                    </links>
                 </configuration>
             </plugin>
             <plugin>

--- a/testing/src/main/java/org/apidesign/javadoc/testing/UseFlux.java
+++ b/testing/src/main/java/org/apidesign/javadoc/testing/UseFlux.java
@@ -31,7 +31,7 @@ public class UseFlux {
     }
 
     /**
-     * Returns a {@link Flux} of integers.
+     * Returns a {@link Flux} of {@link Integer integers}.
      *
      * @return A flux of integers.
      */

--- a/testing/src/test/java/org/apidesign/javadoc/testing/VerifyJavadocTest.java
+++ b/testing/src/test/java/org/apidesign/javadoc/testing/VerifyJavadocTest.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.*;
 
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import org.testng.annotations.Test;
 
 // BEGIN: sampleClass
@@ -235,6 +236,27 @@ public class VerifyJavadocTest {
         String text = new String(data);
         assertSnippet(text, "dollarSnippet1", "MY_MONEY = <em>\"$100.00\"</em>");
         assertSnippet(text, "dollarSnippet2", "MONEY_SIGNS = <em>\"$ € £\"</em>");
+    }
+
+    @Test
+    public void testPackageListElementListExists() {
+        String packageListFileName = "javadoc-bundle-options/package-list";
+        int javaSpecVersion;
+        String javaSpecVersionProperty = System.getProperty("java.specification.version");
+        try {
+            // JDK 9 and above have properties set as "9", "10"...
+            // JDK 8 and below have this property set as "1.8", "1.7"
+            // https://openjdk.java.net/jeps/223
+            javaSpecVersion = Integer.parseInt(javaSpecVersionProperty);
+        } catch (NumberFormatException ex) {
+            javaSpecVersion = Integer
+                .parseInt(javaSpecVersionProperty.substring(javaSpecVersionProperty.indexOf('.') + 1));
+        }
+        if (javaSpecVersion >= 10) {
+            packageListFileName = "javadoc-bundle-options/element-list";
+        }
+        File file = Paths.get("target", packageListFileName).toFile();
+        assertTrue(file.exists(), "File found " + file);
     }
 
     private void assertSnippet(String text, final String snippetKey, final String snippetText) {

--- a/testing/src/test/java/org/apidesign/javadoc/testing/VerifyJavadocTest.java
+++ b/testing/src/test/java/org/apidesign/javadoc/testing/VerifyJavadocTest.java
@@ -20,6 +20,7 @@ package org.apidesign.javadoc.testing;
 import java.io.File;
 import static org.testng.Assert.*;
 
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -257,6 +258,20 @@ public class VerifyJavadocTest {
         }
         File file = Paths.get("target", packageListFileName).toFile();
         assertTrue(file.exists(), "File found " + file);
+    }
+
+    @Test
+    public void testElementListLinks() throws Exception {
+        ClassLoader l = VerifyJavadocTest.class.getClassLoader();
+        URL url = l.getResource("apidocs/org/apidesign/javadoc/testing/UseFlux.html");
+        assertNotNull(url, "Generated page for package found");
+        File file = new File(url.toURI());
+        assertTrue(file.exists(), "File found " + file);
+
+        byte[] data = Files.readAllBytes(file.toPath());
+        String text = new String(data);
+        assertNotEquals(text.indexOf("/Flux.html"), -1, "Checks for existence of link to Flux");
+        assertNotEquals(text.indexOf("/Integer.html"), -1, "Checks for existence of link to Integer");
     }
 
     private void assertSnippet(String text, final String snippetKey, final String snippetText) {


### PR DESCRIPTION
Since JDK 10, the name of the file containing package list was changed from `package-list` to `element-list`. This PR checks for existence of either of these files to read the package list.

Fixes #20 