### PR TITLE
Support for JDK 17

### DIFF
--- a/doclet/src/main/java/com/sun/tools/oldlets/formats/html/ConfigurationImpl.java
+++ b/doclet/src/main/java/com/sun/tools/oldlets/formats/html/ConfigurationImpl.java
@@ -44,6 +44,8 @@ import com.sun.tools.javac.util.StringUtils;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.concurrent.Callable;
+
+import org.apidesign.javadoc.codesnippet.impl.DocLintUtils;
 import org.apidesign.javadoc.codesnippet.impl.Profiles;
 
 /**
@@ -509,7 +511,7 @@ public class ConfigurationImpl extends Configuration {
                     reporter.printError(getText("doclet.Option_doclint_no_qualifiers"));
                     return false;
                 }
-                if (!DocLint.isValidOption(
+                if (!DocLintUtils.isValidOption(
                         opt.replace("-xdoclint:", DocLint.XMSGS_CUSTOM_PREFIX))) {
                     reporter.printError(getText("doclet.Option_doclint_invalid_arg"));
                     return false;

--- a/doclet/src/main/java/com/sun/tools/oldlets/javadoc/main/DocEnv.java
+++ b/doclet/src/main/java/com/sun/tools/oldlets/javadoc/main/DocEnv.java
@@ -52,6 +52,7 @@ import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.Name;
 import com.sun.tools.javac.util.Names;
+import org.apidesign.javadoc.codesnippet.impl.DocLintUtils;
 
 /**
  * Holds the environment for a run of javadoc.
@@ -840,12 +841,12 @@ public class DocEnv {
             customTags.append(customTag);
             sep = ",";
         }
-        doclintOpts.add(DocLint.XCUSTOM_TAGS_PREFIX + customTags.toString());
+        doclintOpts.add(DocLintUtils.XCUSTOM_TAGS_PREFIX + customTags.toString());
         doclintOpts.add("-XhtmlVersion:" + htmlVersion);
 
         JavacTask t = BasicJavacTask.instance(context);
-        doclint = new DocLint();
-        doclint.init(t, doclintOpts.toArray(new String[doclintOpts.size()]), false);
+        doclint = DocLintUtils.getDocLint();
+        DocLintUtils.init(doclint, t, doclintOpts.toArray(new String[doclintOpts.size()]), false);
     }
 
     JavaScriptScanner initJavaScriptScanner(boolean allowScriptInComments) {

--- a/doclet/src/main/java/com/sun/tools/oldlets/javadoc/main/DocImpl.java
+++ b/doclet/src/main/java/com/sun/tools/oldlets/javadoc/main/DocImpl.java
@@ -42,6 +42,7 @@ import com.sun.source.util.TreePath;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.util.Position;
+import org.apidesign.javadoc.codesnippet.impl.DocLintUtils;
 
 /**
  * abstract base class of all Doc classes.  Doc item's are representations
@@ -143,7 +144,7 @@ public abstract class DocImpl implements Doc, Comparable<Object> {
                     && treePath != null
                     && env.shouldCheck(treePath.getCompilationUnit())
                     && d.equals(getCommentText(treePath))) {
-                env.doclint.scan(treePath);
+                DocLintUtils.scan(env.doclint, treePath);
             }
             comment = new Comment(this, d);
         }

--- a/doclet/src/main/java/com/sun/tools/oldlets/javadoc/main/Messager.java
+++ b/doclet/src/main/java/com/sun/tools/oldlets/javadoc/main/Messager.java
@@ -118,7 +118,7 @@ public class Messager extends Log implements DocErrorReporter {
                        PrintWriter errWriter,
                        PrintWriter warnWriter,
                        PrintWriter noticeWriter) {
-        super(context, errWriter, warnWriter, noticeWriter);
+        super(context, noticeWriter);
         messages = JavacMessages.instance(context);
         SymbolKind.addResourceBundle(messages, "com.sun.tools.oldlets.javadoc.main.javadoc");
         javadocDiags = new JCDiagnostic.Factory(messages, "javadoc");

--- a/doclet/src/main/java/org/apidesign/javadoc/codesnippet/impl/DocLintUtils.java
+++ b/doclet/src/main/java/org/apidesign/javadoc/codesnippet/impl/DocLintUtils.java
@@ -1,0 +1,93 @@
+package org.apidesign.javadoc.codesnippet.impl;
+
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.TreePath;
+import com.sun.tools.doclint.DocLint;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class DocLintUtils {
+    private static Class<?> docLintClass;
+    private static DocLint docLint;
+
+    static {
+        try {
+            docLintClass = Class.forName("com.sun.tools.doclint.DocLint");
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static int getVersion() {
+        String version = System.getProperty("java.version");
+        if (version.startsWith("1.")) {
+            version = version.substring(2, 3);
+        } else {
+            final int dot = version.indexOf(".");
+            if (dot != -1) {
+                version = version.substring(0, dot);
+            }
+        }
+        return Integer.parseInt(version);
+    }
+
+    public static String XCUSTOM_TAGS_PREFIX = "-XcustomTags:";
+
+    public static DocLint getDocLint() {
+        if (docLint == null) {
+            try {
+                if (getVersion() <= 8) {
+                    // new DocLint()
+                    docLint = (DocLint) docLintClass.getConstructors()[0].newInstance();
+                } else {
+                    // DocLint.newDocLint()
+                    docLint = (DocLint) docLintClass.getDeclaredMethod("newDocLint").invoke(null);
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        return docLint;
+    }
+
+    public static boolean isValidOption(String s) {
+        try {
+            if (getVersion() <= 8) {
+                // DocLint.isValidOption(s) - static method
+                return (boolean) docLintClass.getDeclaredMethod("isValidOption", String.class).invoke(null, s);
+            } else {
+                // getDocLint().isValidOption(s) - instance method
+                return (boolean) docLintClass.getDeclaredMethod("isValidOption", String.class).invoke(getDocLint(), s);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+    public static void init(DocLint doclint, JavacTask t, String[] doclintOpts, boolean b) {
+        try {
+            if (getVersion() <= 8) {
+                // doclint.init(t, doclintOpts, b)
+                docLintClass.getDeclaredMethod("init", JavacTask.class, String[].class, boolean.class)
+                    .invoke(doclint, t, doclintOpts, b);
+            } else {
+                // doclint.init(t, doclintOpts);
+                docLintClass.getDeclaredMethod("init", JavacTask.class, String[].class)
+                    .invoke(doclint, t, doclintOpts);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void scan(DocLint doclint, TreePath treePath) {
+        try {
+            // doclint.scan(treePath)
+            docLintClass.getDeclaredMethod("scan", TreePath.class).invoke(doclint, treePath);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Attempting to support DocLint from JDK 8 through JDK 17 with a little bit of reflection to pave over API changes. This is tested locally against the unit tests in the codesnippet4javadoc project, but has not been tested on a real-world project (which will happen before I mark this PR non-draft). In the meanwhile I am creating this PR to at least get that ball rolling and any further discussion had. Let me know if you are open to such a PR when testing is complete. Thanks.

Fixes #24
Fixes #25