### PR TITLE
fix incorrect cast

### DIFF
--- a/doclet/src/main/java/com/sun/tools/oldlets/internal/toolkit/util/Extern.java
+++ b/doclet/src/main/java/com/sun/tools/oldlets/internal/toolkit/util/Extern.java
@@ -258,11 +258,14 @@ public class Extern {
         // First check if package/list/url/path/package-list exists. If this url returns 404, then use
         // package/list/url/path/element-list
         URL link = pkglisturlpath.toURI().resolve(DocPaths.PACKAGE_LIST.getPath()).toURL();
-        HttpURLConnection connection = (HttpURLConnection) link.openConnection();
-        connection.setRequestMethod("GET");
-        connection.connect();
-        if (connection.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
-            link = pkglisturlpath.toURI().resolve(DocPaths.ELEMENT_LIST.getPath()).toURL();
+        URLConnection connection = link.openConnection();
+        if (connection instanceof HttpURLConnection) {
+            HttpURLConnection httpConnection = (HttpURLConnection) connection;
+            httpConnection.setRequestMethod("GET");
+            httpConnection.connect();
+            if (httpConnection.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+                link = pkglisturlpath.toURI().resolve(DocPaths.ELEMENT_LIST.getPath()).toURL();
+            }
         }
         return link;
     }


### PR DESCRIPTION
Hi @jtulach , I was trying to upgrade the codesnippet for Apache NetBeans javadoc to build against jdk 11 but I encounter an issue seen in the following jira ticket:
https://issues.apache.org/jira/browse/NETBEANS-6386.

There is no guarantee to have a HttpURLconnection it can be an incompatible FileURLConnection.

