### PR TITLE
Support JDK-21

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        java: [ '8', '11', '13', '14', '15', '17', '18' ]
+        java: [ '8', '11', '13', '14', '15', '17', '21-ea' ]
         
     steps:
     - uses: actions/checkout@v2

--- a/doclet-test/pom.xml
+++ b/doclet-test/pom.xml
@@ -57,8 +57,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/doclet/src/main/java/com/sun/tools/oldlets/formats/html/ConfigurationImpl.java
+++ b/doclet/src/main/java/com/sun/tools/oldlets/formats/html/ConfigurationImpl.java
@@ -466,7 +466,7 @@ public class ConfigurationImpl extends Configuration {
                 nohelp = true;
             } else if (opt.equals("-xdocrootparent")) {
                 try {
-                    new URL(os[1]);
+                    verifyURL(os[1]);
                 } catch (MalformedURLException e) {
                     reporter.printError(getText("doclet.MalformedURL", os[1]));
                     return false;
@@ -517,6 +517,11 @@ public class ConfigurationImpl extends Configuration {
             }
         }
         return true;
+    }
+
+    @SuppressWarnings("deprecation")
+    private void verifyURL(String url) throws MalformedURLException {
+        new URL(url);
     }
 
     /**

--- a/doclet/src/main/java/com/sun/tools/oldlets/internal/toolkit/util/Extern.java
+++ b/doclet/src/main/java/com/sun/tools/oldlets/internal/toolkit/util/Extern.java
@@ -190,6 +190,7 @@ public class Extern {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private URL toURL(String url) throws Fault {
         try {
             return new URL(url);
@@ -347,6 +348,7 @@ public class Extern {
         }
     }
 
+    @SuppressWarnings("deprecation")
     public boolean isUrl (String urlCandidate) {
         try {
             new URL(urlCandidate);

--- a/doclet/src/main/java/com/sun/tools/oldlets/javadoc/main/CommandLine.java
+++ b/doclet/src/main/java/com/sun/tools/oldlets/javadoc/main/CommandLine.java
@@ -1,0 +1,295 @@
+package com.sun.tools.oldlets.javadoc.main;
+/*
+ * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Various utility methods for processing Java tool command line arguments.
+ *
+ *  <p><b>This is NOT part of any supported API.
+ *  If you write code that depends on this, you do so at your own risk.
+ *  This code and its internal interfaces are subject to change or
+ *  deletion without notice.</b>
+ */
+class CommandLine {
+    /**
+     * Process Win32-style command files for the specified command line
+     * arguments and return the resulting arguments. A command file argument
+     * is of the form '@file' where 'file' is the name of the file whose
+     * contents are to be parsed for additional arguments. The contents of
+     * the command file are parsed using StreamTokenizer and the original
+     * '@file' argument replaced with the resulting tokens. Recursive command
+     * files are not supported. The '@' character itself can be quoted with
+     * the sequence '@@'.
+     * @param args the arguments that may contain @files
+     * @return the arguments, with @files expanded
+     * @throws IOException if there is a problem reading any of the @files
+     */
+    public static List<String> parse(List<String> args) throws IOException {
+        List<String> newArgs = new ArrayList<>();
+        appendParsedCommandArgs(newArgs, args);
+        return newArgs;
+    }
+
+    private static void appendParsedCommandArgs(List<String> newArgs, List<String> args) throws IOException {
+        for (String arg : args) {
+            if (arg.length() > 1 && arg.charAt(0) == '@') {
+                arg = arg.substring(1);
+                if (arg.charAt(0) == '@') {
+                    newArgs.add(arg);
+                } else {
+                    loadCmdFile(arg, newArgs);
+                }
+            } else {
+                newArgs.add(arg);
+            }
+        }
+    }
+
+    /**
+     * Process the given environment variable and appends any Win32-style
+     * command files for the specified command line arguments and return
+     * the resulting arguments. A command file argument
+     * is of the form '@file' where 'file' is the name of the file whose
+     * contents are to be parsed for additional arguments. The contents of
+     * the command file are parsed using StreamTokenizer and the original
+     * '@file' argument replaced with the resulting tokens. Recursive command
+     * files are not supported. The '@' character itself can be quoted with
+     * the sequence '@@'.
+     * @param envVariable the env variable to process
+     * @param args the arguments that may contain @files
+     * @return the arguments, with environment variable's content and expansion of @files
+     * @throws IOException if there is a problem reading any of the @files
+     * @throws com.sun.tools.javac.main.CommandLine.UnmatchedQuote
+     */
+    public static List<String> parse(String envVariable, List<String> args)
+            throws IOException, UnmatchedQuote {
+
+        List<String> inArgs = new ArrayList<>();
+        appendParsedEnvVariables(inArgs, envVariable);
+        inArgs.addAll(args);
+        List<String> newArgs = new ArrayList<>();
+        appendParsedCommandArgs(newArgs, inArgs);
+        return newArgs;
+    }
+
+    private static void loadCmdFile(String name, List<String> args) throws IOException {
+        try (Reader r = Files.newBufferedReader(Paths.get(name), Charset.defaultCharset())) {
+            Tokenizer t = new Tokenizer(r);
+            String s;
+            while ((s = t.nextToken()) != null) {
+                args.add(s);
+            }
+        }
+    }
+
+    public static class Tokenizer {
+        private final Reader in;
+        private int ch;
+
+        public Tokenizer(Reader in) throws IOException {
+            this.in = in;
+            ch = in.read();
+        }
+
+        public String nextToken() throws IOException {
+            skipWhite();
+            if (ch == -1) {
+                return null;
+            }
+
+            StringBuilder sb = new StringBuilder();
+            char quoteChar = 0;
+
+            while (ch != -1) {
+                switch (ch) {
+                    case ' ':
+                    case '\t':
+                    case '\f':
+                        if (quoteChar == 0) {
+                            return sb.toString();
+                        }
+                        sb.append((char) ch);
+                        break;
+
+                    case '\n':
+                    case '\r':
+                        return sb.toString();
+
+                    case '\'':
+                    case '"':
+                        if (quoteChar == 0) {
+                            quoteChar = (char) ch;
+                        } else if (quoteChar == ch) {
+                            quoteChar = 0;
+                        } else {
+                            sb.append((char) ch);
+                        }
+                        break;
+
+                    case '\\':
+                        if (quoteChar != 0) {
+                            ch = in.read();
+                            switch (ch) {
+                                case '\n':
+                                case '\r':
+                                    while (ch == ' ' || ch == '\n' || ch == '\r' || ch == '\t' || ch == '\f') {
+                                        ch = in.read();
+                                    }
+                                    continue;
+
+                                case 'n':
+                                    ch = '\n';
+                                    break;
+                                case 'r':
+                                    ch = '\r';
+                                    break;
+                                case 't':
+                                    ch = '\t';
+                                    break;
+                                case 'f':
+                                    ch = '\f';
+                                    break;
+                            }
+                        }
+                        sb.append((char) ch);
+                        break;
+
+                    default:
+                        sb.append((char) ch);
+                }
+
+                ch = in.read();
+            }
+
+            return sb.toString();
+        }
+
+        void skipWhite() throws IOException {
+            while (ch != -1) {
+                switch (ch) {
+                    case ' ':
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                        break;
+
+                    case '#':
+                        ch = in.read();
+                        while (ch != '\n' && ch != '\r' && ch != -1) {
+                            ch = in.read();
+                        }
+                        break;
+
+                    default:
+                        return;
+                }
+
+                ch = in.read();
+            }
+        }
+    }
+
+    @SuppressWarnings("fallthrough")
+    private static void appendParsedEnvVariables(List<String> newArgs, String envVariable)
+            throws UnmatchedQuote {
+
+        if (envVariable == null) {
+            return;
+        }
+        String in = System.getenv(envVariable);
+        if (in == null || in.trim().isEmpty()) {
+            return;
+        }
+
+        final char NUL = (char)0;
+        final int len = in.length();
+
+        int pos = 0;
+        StringBuilder sb = new StringBuilder();
+        char quote = NUL;
+        char ch;
+
+        loop:
+        while (pos < len) {
+            ch = in.charAt(pos);
+            switch (ch) {
+                case '\"': case '\'':
+                    if (quote == NUL) {
+                        quote = ch;
+                    } else if (quote == ch) {
+                        quote = NUL;
+                    } else {
+                        sb.append(ch);
+                    }
+                    pos++;
+                    break;
+                case '\f': case '\n': case '\r': case '\t': case ' ':
+                    if (quote == NUL) {
+                        newArgs.add(sb.toString());
+                        sb.setLength(0);
+                        while (ch == '\f' || ch == '\n' || ch == '\r' || ch == '\t' || ch == ' ') {
+                            pos++;
+                            if (pos >= len) {
+                                break loop;
+                            }
+                            ch = in.charAt(pos);
+                        }
+                        break;
+                    }
+                    // fall through
+                default:
+                    sb.append(ch);
+                    pos++;
+            }
+        }
+        if (sb.length() != 0) {
+            newArgs.add(sb.toString());
+        }
+        if (quote != NUL) {
+            throw new UnmatchedQuote(envVariable);
+        }
+    }
+
+    public static class UnmatchedQuote extends Exception {
+        private static final long serialVersionUID = 0;
+
+        public final String variableName;
+
+        UnmatchedQuote(String variable) {
+            this.variableName = variable;
+        }
+    }
+}

--- a/doclet/src/main/java/com/sun/tools/oldlets/javadoc/main/Start.java
+++ b/doclet/src/main/java/com/sun/tools/oldlets/javadoc/main/Start.java
@@ -39,7 +39,6 @@ import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 
 import com.sun.tools.javac.file.JavacFileManager;
-import com.sun.tools.javac.main.CommandLine;
 import com.sun.tools.javac.main.Option;
 import com.sun.tools.javac.main.OptionHelper;
 import com.sun.tools.javac.main.OptionHelper.GrumpyHelper;
@@ -278,27 +277,7 @@ public class Start extends ToolOption.Helper {
         ListBuffer<String> javaNames = new ListBuffer<>();
 
         // Preprocess @file arguments
-        FOUND: try {
-            for (Method m : CommandLine.class.getMethods()) {
-                if (m.getName().equals("parse") && m.getParameterCount() == 1) {
-                    if (m.getParameterTypes()[0] == String[].class) {
-                        argv = (String[]) m.invoke(null, (Object) argv);
-                    } else {
-                        assert m.getParameterTypes()[0] == java.util.List.class;
-                        java.util.List<?> ret = (java.util.List<?>) m.invoke(null, Arrays.asList(argv));
-                        argv = ret.toArray(new String[0]);
-                    }
-                    break FOUND;
-                }
-            }
-        } catch (ReflectiveOperationException e) {
-            if (e.getCause() instanceof FileNotFoundException) {
-                messager.error(Messager.NOPOS, "main.cant.read", e.getCause().getMessage());
-                exit();
-            }
-            e.printStackTrace(System.err);
-            exit();
-        }
+        argv = CommandLine.parse(Arrays.asList(argv)).toArray(new String[0]);
 
 
         fileManager = context.get(JavaFileManager.class);

--- a/doclet/src/main/java/org/apidesign/javadoc/codesnippet/SnippetCollection.java
+++ b/doclet/src/main/java/org/apidesign/javadoc/codesnippet/SnippetCollection.java
@@ -57,6 +57,9 @@ final class SnippetCollection {
         String code = snip == null ? null : snip.get(key);
         if (code == null) {
             reporter.printWarning(element.position(), code = "Snippet '" + key + "' in file '" + file + "' not found.");
+            for (String f : perFileSnippets.keySet()) {
+                reporter.printWarning(element.position(), code = "  ... some snippets found in " + f);
+            }
         }
         return code;
     }

--- a/testing/src/main/java/org/apidesign/javadoc/testing/EmbeddingSampleCode.java
+++ b/testing/src/main/java/org/apidesign/javadoc/testing/EmbeddingSampleCode.java
@@ -33,7 +33,7 @@ public final class EmbeddingSampleCode {
      * {@link EmbeddedSnippet#fourtyTwo}
      * Put the class at the end of the API file (it needs to be package private)
      * and it is guaranteed your snippet code will properly compile every
-     * time your {@link Compiler API compiles}.
+     * time your API compiles.
      *
      * @param x first number
      * @param y second number


### PR DESCRIPTION
Resolves #32 by copying the `CommandLine` class into this project. Such a copy removes the need for reflection that mitigated differences between JDK-8 version of `CommandLine` and the latest one.